### PR TITLE
Add helper.sh to vagrant:/etc/profile.d

### DIFF
--- a/files/helper.sh
+++ b/files/helper.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Helpful shell aliases and functions to make deployment easier
+
+export LS_OPTIONS='--color=auto'
+alias ll="ls $LS_OPTIONS -l"
+alias l="ls $LS_OPTIONS -lA"
+
+# update the suders file on all running targets
+update-sudoers() {
+    sudo -v
+
+    for container in $(sudo lxc-ls -1 --running); do
+        sudo cat /vagrant/files/sudoers | \
+            sudo lxc-attach -n "$container" -- sh -c 'cat > /etc/sudoers.d/mockbase'
+    done
+}
+
+# Run a command on all running targets
+targets() {
+    sudo -v
+
+    local cmd="$@"
+
+    for container in $(sudo lxc-ls -1 --running); do
+        printf "\n${container}:\n"
+        sudo lxc-attach -n "$container" -- sh -c "$cmd"
+    done
+}

--- a/setup.sh
+++ b/setup.sh
@@ -100,6 +100,9 @@ fi
 # Add scap project directory to our PATH
 echo 'PATH=/vagrant/scap/bin:"$PATH"' > /etc/profile.d/scap.sh
 
+# Add helper functions to profile
+install -o root -m 0644 /vagrant/files/helper.sh /etc/profile.d/
+
 # Create deployment environment
 if ! [ -d /srv/deployment ]; then
   mkdir -p /srv/deployment


### PR DESCRIPTION
This adds a few commands that I've found useful when using this box to
develop. One command to update the sudoers file on all targets, and one to
run an arbitrary command on all targets. This is helpful when trying to
cause a failure.
