### PR TITLE
Checkout revs to [repo]-cache

### DIFF
--- a/files/mockbase/mockbase.service
+++ b/files/mockbase/mockbase.service
@@ -3,7 +3,7 @@ Description=MockBase test service
 After=network.target
 
 [Service]
-ExecStart=/srv/deployment/mockbase/deploy/current/mockbase/server
+ExecStart=/srv/deployment/mockbase/deploy/mockbase/server
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 Restart=on-failure

--- a/setup.sh
+++ b/setup.sh
@@ -203,8 +203,8 @@ if [ -z "$(lxc-ls -1 $BASE_CONTAINER)" ]; then
   mkdir -p /var/lib/lxc/$BASE_CONTAINER/rootfs/srv/deployment/scap/scap
 
   echo 'Setting up mockbase in base container'
-  mkdir -p /var/lib/lxc/$BASE_CONTAINER/rootfs/$DEPLOY_DIR
-  chown vagrant:vagrant /var/lib/lxc/$BASE_CONTAINER/rootfs/$DEPLOY_DIR
+  mkdir -p "/var/lib/lxc/$BASE_CONTAINER/rootfs/${DEPLOY_DIR}-cache"
+  chown -R vagrant:vagrant "/var/lib/lxc/$BASE_CONTAINER/rootfs/$(dirname $DEPLOY_DIR)"
   mkdir -p /var/lib/lxc/$BASE_CONTAINER/rootfs/etc/mockbase
   cp /vagrant/files/mockbase/mockbase.service /var/lib/lxc/$BASE_CONTAINER/rootfs/etc/mockbase/
   cat > /var/lib/lxc/$BASE_CONTAINER/rootfs/etc/mockbase/config-vars.yaml <<-end


### PR DESCRIPTION
When https://gerrit.wikimedia.org/r/#/c/241684/ merges to preserve
backwards compatibility with trebuchet, this will need to merge.

This makes the final path to the server executable
/srv/deployment/mockbase/deploy/mockbase/server

It also puts in place the /srv/deployment/mockbase/deploy-cache
directory which is the directory where revs, cache, and current will be
stored.
