### PR TITLE
Move scap.cfg config_files to config-files.yaml

### DIFF
--- a/files/deploy/scap/config-files.yaml
+++ b/files/deploy/scap/config-files.yaml
@@ -1,0 +1,3 @@
+/tmp/mockbase-config.yaml:
+    template: config.yaml.j2
+    remote_vars: /etc/mockbase/config-vars.yaml

--- a/files/deploy/scap/scap.cfg
+++ b/files/deploy/scap/scap.cfg
@@ -11,8 +11,3 @@ service_name: mockbase
 service_port: 1134
 batch_size: 80
 config_deploy: True
-
-[config_files]
-/tmp/mockbase-config.yaml:
-  template: config.yaml.j2
-  vars_file: /etc/mockbase/config-vars.yaml


### PR DESCRIPTION
When https://gerrit.wikimedia.org/r/#/c/240292/ merges, the config file
deployment configuration will be in `[repo]/scap/config-files.yaml` and
not in `[repo]/scap/scap.cfg`.
